### PR TITLE
Update Buildings_Ancient_Outdoors.xml

### DIFF
--- a/Ideology/DefInjected/ExpectationDef/Expectations.xml
+++ b/Ideology/DefInjected/ExpectationDef/Expectations.xml
@@ -2,9 +2,9 @@
 <LanguageData>
   
   <!-- EN: elite -->
-  <RoleElite.label>TODO</RoleElite.label>
+  <RoleElite.label>Elite</RoleElite.label>
   
   <!-- EN: supreme -->
-  <RoleSupreme.label>TODO</RoleSupreme.label>
+  <RoleSupreme.label>Supremo</RoleSupreme.label>
   
 </LanguageData>

--- a/Ideology/DefInjected/ThingDef/Buildings_Ancient_Active.xml
+++ b/Ideology/DefInjected/ThingDef/Buildings_Ancient_Active.xml
@@ -2,38 +2,38 @@
 <LanguageData>
   
   <!-- EN: ancient comms console -->
-  <AncientCommsConsole.label>antica console di comunicazione</AncientCommsConsole.label>
+  <AncientCommsConsole.label>TODO</AncientCommsConsole.label>
   <!-- EN: An ancient console with an attached communications dish. Valuable parts are missing, and everything else is degraded to uselessness. -->
-  <AncientCommsConsole.description>Un'antica console con annessa parabola di comunicazione. Mancano parti preziose e tutto il resto è degradato fino all'inutilità.</AncientCommsConsole.description>
+  <AncientCommsConsole.description>TODO</AncientCommsConsole.description>
   
   <!-- EN: ancient cryptosleep pod -->
-  <AncientCryptosleepPod.label>antica capsula di criptosonno</AncientCryptosleepPod.label>
+  <AncientCryptosleepPod.label>TODO</AncientCryptosleepPod.label>
   <!-- EN: A single-use pod for preserving one person in a state of suspended animation. Unlike cryptosleep caskets, cryptosleep pods can only be used once. -->
-  <AncientCryptosleepPod.description>Capsula monouso per conservare una persona in uno stato di animazione sospesa. A differenza degli scrigni per il criptosonno, le capsule per il criptosonno possono essere utilizzate una sola volta.</AncientCryptosleepPod.description>
+  <AncientCryptosleepPod.description>TODO</AncientCryptosleepPod.description>
   
   <!-- EN: ancient enemy terminal -->
-  <AncientEnemyTerminal.label>terminale nemico antico</AncientEnemyTerminal.label>
+  <AncientEnemyTerminal.label>TODO</AncientEnemyTerminal.label>
   <!-- EN: An ancient computer terminal. It can be hacked to call nearby enemies. -->
-  <AncientEnemyTerminal.description>Un antico terminale informatico. Può essere hackerato per chiamare i nemici vicini.</AncientEnemyTerminal.description>
+  <AncientEnemyTerminal.description>TODO</AncientEnemyTerminal.description>
   
   <!-- EN: ancient unstable fuel node -->
-  <AncientFuelNode.label>antico nodo di combustibile instabile</AncientFuelNode.label>
+  <AncientFuelNode.label>TODO</AncientFuelNode.label>
   <!-- EN: An ancient, unstable fuel node once used to charge machines with fuel. It has become unstable over the years due to lack of maintenance. -->
-  <AncientFuelNode.description>Un nodo di carburante antico e instabile, un tempo utilizzato per caricare le macchine con il carburante. Nel corso degli anni è diventato instabile a causa della mancanza di manutenzione.</AncientFuelNode.description>
+  <AncientFuelNode.description>TODO</AncientFuelNode.description>
   
   <!-- EN: hermetic crate -->
-  <AncientHermeticCrate.label>cassa ermetica</AncientHermeticCrate.label>
+  <AncientHermeticCrate.label>TODO</AncientHermeticCrate.label>
   <!-- EN: A self-powered hermetically-sealed crate for preserving valuable items. These can preserve their contents for a long time. -->
-  <AncientHermeticCrate.description>Una cassa autoalimentata a chiusura ermetica per la conservazione di oggetti di valore. Queste casse possono conservare il loro contenuto per lungo tempo.</AncientHermeticCrate.description>
+  <AncientHermeticCrate.description>TODO</AncientHermeticCrate.description>
   
   <!-- EN: security crate -->
-  <AncientSecurityCrate.label>cassa di sicurezza</AncientSecurityCrate.label>
+  <AncientSecurityCrate.label>TODO</AncientSecurityCrate.label>
   <!-- EN: A large self-powered hermetically-sealed crate with built-in security alarms. These can preserve their contents for a long time. If it is opened without the proper code, it will probably activate some nearby security system. -->
-  <AncientSecurityCrate.description>Una grande cassa autoalimentata a chiusura ermetica con allarme di sicurezza incorporato. Queste casse possono conservare il loro contenuto per molto tempo. Se viene aperta senza il codice appropriato, probabilmente attiverà qualche sistema di sicurezza nelle vicinanze.</AncientSecurityCrate.description>
+  <AncientSecurityCrate.description>TODO</AncientSecurityCrate.description>
   
   <!-- EN: ancient terminal -->
-  <AncientTerminal.label>antico terminale</AncientTerminal.label>
+  <AncientTerminal.label>TODO</AncientTerminal.label>
   <!-- EN: An ancient computer terminal. It can be hacked to reveal long-forgotten information. -->
-  <AncientTerminal.description>Un antico terminale di computer. Può essere violato per rivelare informazioni dimenticate da tempo.</AncientTerminal.description>
+  <AncientTerminal.description>TODO</AncientTerminal.description>
   
 </LanguageData>

--- a/Ideology/DefInjected/ThingDef/Buildings_Ancient_Active.xml
+++ b/Ideology/DefInjected/ThingDef/Buildings_Ancient_Active.xml
@@ -2,38 +2,38 @@
 <LanguageData>
   
   <!-- EN: ancient comms console -->
-  <AncientCommsConsole.label>TODO</AncientCommsConsole.label>
+  <AncientCommsConsole.label>antica console di comunicazione</AncientCommsConsole.label>
   <!-- EN: An ancient console with an attached communications dish. Valuable parts are missing, and everything else is degraded to uselessness. -->
-  <AncientCommsConsole.description>TODO</AncientCommsConsole.description>
+  <AncientCommsConsole.description>Un'antica console con annessa parabola di comunicazione. Mancano parti preziose e tutto il resto è degradato fino all'inutilità.</AncientCommsConsole.description>
   
   <!-- EN: ancient cryptosleep pod -->
-  <AncientCryptosleepPod.label>TODO</AncientCryptosleepPod.label>
+  <AncientCryptosleepPod.label>antica capsula di criptosonno</AncientCryptosleepPod.label>
   <!-- EN: A single-use pod for preserving one person in a state of suspended animation. Unlike cryptosleep caskets, cryptosleep pods can only be used once. -->
-  <AncientCryptosleepPod.description>TODO</AncientCryptosleepPod.description>
+  <AncientCryptosleepPod.description>Capsula monouso per conservare una persona in uno stato di animazione sospesa. A differenza degli scrigni per il criptosonno, le capsule per il criptosonno possono essere utilizzate una sola volta.</AncientCryptosleepPod.description>
   
   <!-- EN: ancient enemy terminal -->
-  <AncientEnemyTerminal.label>TODO</AncientEnemyTerminal.label>
+  <AncientEnemyTerminal.label>terminale nemico antico</AncientEnemyTerminal.label>
   <!-- EN: An ancient computer terminal. It can be hacked to call nearby enemies. -->
-  <AncientEnemyTerminal.description>TODO</AncientEnemyTerminal.description>
+  <AncientEnemyTerminal.description>Un antico terminale informatico. Può essere hackerato per chiamare i nemici vicini.</AncientEnemyTerminal.description>
   
   <!-- EN: ancient unstable fuel node -->
-  <AncientFuelNode.label>TODO</AncientFuelNode.label>
+  <AncientFuelNode.label>antico nodo di combustibile instabile</AncientFuelNode.label>
   <!-- EN: An ancient, unstable fuel node once used to charge machines with fuel. It has become unstable over the years due to lack of maintenance. -->
-  <AncientFuelNode.description>TODO</AncientFuelNode.description>
+  <AncientFuelNode.description>Un nodo di carburante antico e instabile, un tempo utilizzato per caricare le macchine con il carburante. Nel corso degli anni è diventato instabile a causa della mancanza di manutenzione.</AncientFuelNode.description>
   
   <!-- EN: hermetic crate -->
-  <AncientHermeticCrate.label>TODO</AncientHermeticCrate.label>
+  <AncientHermeticCrate.label>cassa ermetica</AncientHermeticCrate.label>
   <!-- EN: A self-powered hermetically-sealed crate for preserving valuable items. These can preserve their contents for a long time. -->
-  <AncientHermeticCrate.description>TODO</AncientHermeticCrate.description>
+  <AncientHermeticCrate.description>Una cassa autoalimentata a chiusura ermetica per la conservazione di oggetti di valore. Queste casse possono conservare il loro contenuto per lungo tempo.</AncientHermeticCrate.description>
   
   <!-- EN: security crate -->
-  <AncientSecurityCrate.label>TODO</AncientSecurityCrate.label>
+  <AncientSecurityCrate.label>cassa di sicurezza</AncientSecurityCrate.label>
   <!-- EN: A large self-powered hermetically-sealed crate with built-in security alarms. These can preserve their contents for a long time. If it is opened without the proper code, it will probably activate some nearby security system. -->
-  <AncientSecurityCrate.description>TODO</AncientSecurityCrate.description>
+  <AncientSecurityCrate.description>Una grande cassa autoalimentata a chiusura ermetica con allarme di sicurezza incorporato. Queste casse possono conservare il loro contenuto per molto tempo. Se viene aperta senza il codice appropriato, probabilmente attiverà qualche sistema di sicurezza nelle vicinanze.</AncientSecurityCrate.description>
   
   <!-- EN: ancient terminal -->
-  <AncientTerminal.label>TODO</AncientTerminal.label>
+  <AncientTerminal.label>antico terminale</AncientTerminal.label>
   <!-- EN: An ancient computer terminal. It can be hacked to reveal long-forgotten information. -->
-  <AncientTerminal.description>TODO</AncientTerminal.description>
+  <AncientTerminal.description>Un antico terminale di computer. Può essere violato per rivelare informazioni dimenticate da tempo.</AncientTerminal.description>
   
 </LanguageData>

--- a/Ideology/DefInjected/ThingDef/Buildings_Ancient_Outdoors.xml
+++ b/Ideology/DefInjected/ThingDef/Buildings_Ancient_Outdoors.xml
@@ -2,187 +2,187 @@
 <LanguageData>
   
   <!-- EN: ancient air conditioner -->
-  <AncientAirConditioner.label>TODO</AncientAirConditioner.label>
+  <AncientAirConditioner.label>condizionatore antico</AncientAirConditioner.label>
   <!-- EN: An ancient air conditioning machine. Its internals were smashed long ago and what wasn't looted has rusted away in the time since. -->
-  <AncientAirConditioner.description>TODO</AncientAirConditioner.description>
+  <AncientAirConditioner.description>Un'antica macchina per l'aria condizionata. I suoi interni sono stati distrutti molto tempo fa e ciò che non è stato saccheggiato si è arrugginito nel tempo.</AncientAirConditioner.description>
   
   <!-- EN: ancient fence -->
-  <AncientFence.label>TODO</AncientFence.label>
+  <AncientFence.label>recinto antico</AncientFence.label>
   <!-- EN: An ancient fence made of reinforced concrete posts joined by concrete panels. -->
   <AncientFence.description>TODO</AncientFence.description>
   
   <!-- EN: ancient giant wheel -->
-  <AncientGiantWheel.label>TODO</AncientGiantWheel.label>
+  <AncientGiantWheel.label>antica ruota gigante</AncientGiantWheel.label>
   <!-- EN: A giant wheel which came off some large vehicle many ages ago. The rubber has disintegrated away and the metal is twisted and rusted. -->
   <AncientGiantWheel.description>TODO</AncientGiantWheel.description>
   
   <!-- EN: ancient jet engine -->
-  <AncientJetEngine.label>TODO</AncientJetEngine.label>
+  <AncientJetEngine.label>antico motore a reazione</AncientJetEngine.label>
   <!-- EN: An ancient jet engine, probably detached from a large airplane. Its delicate internals are rusted to uselessness, and the valuable parts were looted long ago. -->
   <AncientJetEngine.description>TODO</AncientJetEngine.description>
   
   <!-- EN: ancient kitchen sink -->
-  <AncientKitchenSink.label>TODO</AncientKitchenSink.label>
+  <AncientKitchenSink.label>antico lavello da cucina</AncientKitchenSink.label>
   <!-- EN: An ancient kitchen sink made of some non-metallic fiber-sheet material. It is badly deteriorated and there's no way to salvage anything from it.\n\nHow it got here must be a long story. -->
   <AncientKitchenSink.description>TODO</AncientKitchenSink.description>
   
   <!-- EN: ancient large crate -->
-  <AncientLargeCrate.label>TODO</AncientLargeCrate.label>
+  <AncientLargeCrate.label>cassa grande antica</AncientLargeCrate.label>
   <!-- EN: A large crate which was abandoned ages ago. It's too rusted to store anything. -->
   <AncientLargeCrate.description>TODO</AncientLargeCrate.description>
   
   <!-- EN: ancient macro-engine block -->
-  <AncientLargeRustedEngineBlock.label>TODO</AncientLargeRustedEngineBlock.label>
+  <AncientLargeRustedEngineBlock.label>antico blocco del macromotore</AncientLargeRustedEngineBlock.label>
   <!-- EN: An large, ancient engine block from some giant vehicle or power source. It's rusted through, and all the useful components are gone. No repair could salvage this. -->
   <AncientLargeRustedEngineBlock.description>TODO</AncientLargeRustedEngineBlock.description>
   
   <!-- EN: ancient long crate -->
-  <AncientLongCrate.label>TODO</AncientLongCrate.label>
+  <AncientLongCrate.label>cassa lunga antica</AncientLongCrate.label>
   <!-- EN: A long, empty crate which was abandoned ages ago. It's too rusted to store anything. -->
   <AncientLongCrate.description>TODO</AncientLongCrate.description>
   
   <!-- EN: ancient mechanoid shell -->
-  <AncientMechanoidShell.label>TODO</AncientMechanoidShell.label>
+  <AncientMechanoidShell.label>antico guscio meccanoide</AncientMechanoidShell.label>
   <!-- EN: A shell from a smashed mechanoid. It has been deteriorating for many years and the useful components have disintegrated. -->
-  <AncientMechanoidShell.description>TODO</AncientMechanoidShell.description>
+  <AncientMechanoidShell.description>Guscio di un meccanoide distrutto. Si è deteriorato per molti anni e i componenti utili si sono disintegrati.</AncientMechanoidShell.description>
   
   <!-- EN: ancient mech drop beacon -->
-  <AncientMechDropBeacon.label>TODO</AncientMechDropBeacon.label>
+  <AncientMechDropBeacon.label>antico faro di caduta mech</AncientMechDropBeacon.label>
   <!-- EN: The broken shell of a mech drop beacon. Its useful components are missing and the shell has deteriorated after many years. -->
   <AncientMechDropBeacon.description>TODO</AncientMechDropBeacon.description>
   
   <!-- EN: ancient mega-cannon barrel -->
-  <AncientMegaCannonBarrel.label>TODO</AncientMegaCannonBarrel.label>
+  <AncientMegaCannonBarrel.label>antica canna del megacannone</AncientMegaCannonBarrel.label>
   <!-- EN: A barrel from a long-range cannon for artillery or anti-ship use. When it was new, it must have been frighteningly powerful. Now, it's far beyond repair and every useful component has been looted. -->
-  <AncientMegaCannonBarrel.description>TODO</AncientMegaCannonBarrel.description>
+  <AncientMegaCannonBarrel.description>Canna di un cannone a lunga gittata per artiglieria o antinave. Quando era nuovo, doveva essere spaventosamente potente. Ora è ben poco riparabile e ogni componente utile è stato saccheggiato.</AncientMegaCannonBarrel.description>
   
   <!-- EN: ancient mega-cannon platform -->
-  <AncientMegaCannonTripod.label>TODO</AncientMegaCannonTripod.label>
+  <AncientMegaCannonTripod.label>antica piattaforma per megacannone</AncientMegaCannonTripod.label>
   <!-- EN: A mounting platform that once held some sort of cannon. It has been broken for many years and every useful component was looted long ago. -->
   <AncientMegaCannonTripod.description>TODO</AncientMegaCannonTripod.description>
   
   <!-- EN: ancient warsprinter remains -->
-  <AncientMiniWarwalkerRemains.label>TODO</AncientMiniWarwalkerRemains.label>
+  <AncientMiniWarwalkerRemains.label>resti di antichi stampatori di guerra</AncientMiniWarwalkerRemains.label>
   <!-- EN: The shattered remains of an ancient sub-scale warsprinter. Whatever parts weren't ruined when it was destroyed were looted long ago. -->
-  <AncientMiniWarwalkerRemains.description>TODO</AncientMiniWarwalkerRemains.description>
+  <AncientMiniWarwalkerRemains.description>I resti in frantumi di un'antica stampante da guerra in scala ridotta. Le parti non rovinate dalla distruzione sono state saccheggiate molto tempo fa.</AncientMiniWarwalkerRemains.description>
   
   <!-- EN: ancient pipeline section -->
-  <AncientPipelineSection.label>TODO</AncientPipelineSection.label>
+  <AncientPipelineSection.label>sezione di un antico gasdotto</AncientPipelineSection.label>
   <!-- EN: A section from an ancient pipeline. It once carried some valuable fluid over long distances. Now it's been looted and deteriorated to uselessness. -->
-  <AncientPipelineSection.description>TODO</AncientPipelineSection.description>
+  <AncientPipelineSection.description>Una sezione di un antico oleodotto. Un tempo trasportava un fluido prezioso su lunghe distanze. Ora è stato saccheggiato e deteriorato fino a diventare inutilizzabile.</AncientPipelineSection.description>
   
   <!-- EN: ancient pod car -->
-  <AncientPodCar.label>TODO</AncientPodCar.label>
+  <AncientPodCar.label>antica navicella</AncientPodCar.label>
   <!-- EN: An ancient pod car once capable of automated flight. Its valuable parts were looted long ago, and the rest is badly deteriorated. -->
-  <AncientPodCar.description>TODO</AncientPodCar.description>
+  <AncientPodCar.description>Un'antica navicella un tempo in grado di volare in modo automatico. Le sue parti preziose sono state saccheggiate molto tempo fa e il resto è gravemente deteriorato.</AncientPodCar.description>
   
   <!-- EN: ancient postbox -->
-  <AncientPostbox.label>TODO</AncientPostbox.label>
+  <AncientPostbox.label>antica cassetta postale</AncientPostbox.label>
   <!-- EN: An ancient postbox, smashed and deteriorated to uselessness. It seems to have been moved here long ago for some unknown reason. -->
   <AncientPostbox.description>TODO</AncientPostbox.description>
   
   <!-- EN: ancient razor wire -->
-  <AncientRazorWire.label>TODO</AncientRazorWire.label>
+  <AncientRazorWire.label>antico filo spinato</AncientRazorWire.label>
   <!-- EN: A piece of ancient razor wire. It has been deteriorating for many years and no longer poses any danger. -->
   <AncientRazorWire.description>TODO</AncientRazorWire.description>
   
   <!-- EN: ancient refrigerator -->
-  <AncientRefrigerator.label>TODO</AncientRefrigerator.label>
+  <AncientRefrigerator.label>antico frigorifero</AncientRefrigerator.label>
   <!-- EN: An ancient refrigerator. It was stripped of interesting parts long ago. -->
   <AncientRefrigerator.description>TODO</AncientRefrigerator.description>
   
   <!-- EN: ancient car -->
-  <AncientRustedCar.label>TODO</AncientRustedCar.label>
+  <AncientRustedCar.label>auto antica</AncientRustedCar.label>
   <!-- EN: An ancient, broken car. Everything that isn't rusted away was looted long ago. -->
   <AncientRustedCar.description>TODO</AncientRustedCar.description>
   
   <!-- EN: ancient car frame -->
-  <AncientRustedCarFrame.label>TODO</AncientRustedCarFrame.label>
+  <AncientRustedCarFrame.label>telaio di un'auto antica</AncientRustedCarFrame.label>
   <!-- EN: An ancient, rusted car frame. The body shell has long since rusted away to nothing. -->
   <AncientRustedCarFrame.description>TODO</AncientRustedCarFrame.description>
   
   <!-- EN: ancient engine block -->
-  <AncientRustedEngineBlock.label>TODO</AncientRustedEngineBlock.label>
+  <AncientRustedEngineBlock.label>blocco motore antico</AncientRustedEngineBlock.label>
   <!-- EN: An ancient engine block that is rusted through. No repair could salvage this. -->
   <AncientRustedEngineBlock.description>TODO</AncientRustedEngineBlock.description>
   
   <!-- EN: ancient troop carrier -->
-  <AncientRustedJeep.label>TODO</AncientRustedJeep.label>
+  <AncientRustedJeep.label>antico trasporto truppe</AncientRustedJeep.label>
   <!-- EN: An ancient, broken troop carrier. Everything that isn't rusted away was looted long ago. -->
   <AncientRustedJeep.description>TODO</AncientRustedJeep.description>
   
   <!-- EN: ancient security turret -->
-  <AncientSecurityTurret.label>TODO</AncientSecurityTurret.label>
+  <AncientSecurityTurret.label>antica torretta di sicurezza</AncientSecurityTurret.label>
   <!-- EN: An ancient, broken security turret. The valuable parts have all been looted or smashed. -->
   <AncientSecurityTurret.description>TODO</AncientSecurityTurret.description>
   
   <!-- EN: ancient nav beacon -->
-  <AncientShipBeacon.label>TODO</AncientShipBeacon.label>
+  <AncientShipBeacon.label>antico faro navale</AncientShipBeacon.label>
   <!-- EN: An ancient, broken ship navigation beacon. Every useful component was looted long ago. -->
   <AncientShipBeacon.description>TODO</AncientShipBeacon.description>
   
   <!-- EN: ancient shopping cart -->
-  <AncientShoppingCart.label>TODO</AncientShoppingCart.label>
+  <AncientShoppingCart.label>antico carrello della spesa</AncientShoppingCart.label>
   <!-- EN: An ancient, rusted shopping cart. How exactly it got here is a mystery, but the story is long and probably quite sad. -->
   <AncientShoppingCart.description>TODO</AncientShoppingCart.description>
   
   <!-- EN: ancient small crate -->
-  <AncientSmallCrate.label>TODO</AncientSmallCrate.label>
+  <AncientSmallCrate.label>piccola cassa antica</AncientSmallCrate.label>
   <!-- EN: A small, empty crate which was abandoned ages ago. It's too rusted to store anything. -->
   <AncientSmallCrate.description>TODO</AncientSmallCrate.description>
   
   <!-- EN: ancient stove -->
-  <AncientStove.label>TODO</AncientStove.label>
+  <AncientStove.label>stufa antica</AncientStove.label>
   <!-- EN: An ancient stove. Smashed and rusted, it is completely useless now.\n\nHow it got here is hard to say. -->
   <AncientStove.description>TODO</AncientStove.description>
   
   <!-- EN: ancient ruined tank -->
-  <AncientTank.label>TODO</AncientTank.label>
+  <AncientTank.label>antico carro armato in rovina</AncientTank.label>
   <!-- EN: The remains of an ancient tank which was destroyed by some kind of heavy weapon. All the useful components were looted or deteriorated long ago. -->
-  <AncientTank.description>TODO</AncientTank.description>
+  <AncientTank.description>I resti di un antico carro armato distrutto da un qualche tipo di arma pesante. Tutti i componenti utili sono stati saccheggiati o deteriorati molto tempo fa.</AncientTank.description>
   
   <!-- EN: ancient tank trap -->
-  <AncientTankTrap.label>TODO</AncientTankTrap.label>
+  <AncientTankTrap.label>antica trappola per carri armati</AncientTankTrap.label>
   <!-- EN: An defensive fortification for stopping vehicles. It's been deteriorating for many years. -->
   <AncientTankTrap.description>TODO</AncientTankTrap.description>
   
   <!-- EN: ancient vending machine -->
-  <AncientVendingMachine.label>TODO</AncientVendingMachine.label>
+  <AncientVendingMachine.label>antico distributore automatico</AncientVendingMachine.label>
   <!-- EN: An ancient vending machine. It was smashed ages ago and generations of looters have taken every conceivably useful part. How it ended up here is a mystery. -->
   <AncientVendingMachine.description>TODO</AncientVendingMachine.description>
   
   <!-- EN: ancient warspider remains -->
-  <AncientWarspiderRemains.label>TODO</AncientWarspiderRemains.label>
+  <AncientWarspiderRemains.label>resti di antichi ragni da guerra</AncientWarspiderRemains.label>
   <!-- EN: The ruined remains of an ancient mid-scale warspider. It has been picked over many times, and there is nothing valuable left to loot. -->
-  <AncientWarspiderRemains.description>TODO</AncientWarspiderRemains.description>
+  <AncientWarspiderRemains.description>I resti in rovina di un antico ragno da guerra di media grandezza. È stato saccheggiato molte volte e non è rimasto nulla di prezioso da saccheggiare.</AncientWarspiderRemains.description>
   
   <!-- EN: ancient warwalker claw -->
-  <AncientWarwalkerClaw.label>TODO</AncientWarwalkerClaw.label>
+  <AncientWarwalkerClaw.label>antico artiglio del camminatore da guerra</AncientWarwalkerClaw.label>
   <!-- EN: The assault claw of an ancient mid-scale warwalker. This weapon specialized in tearing through heavy plasteel armor at close range. Its valuable components were looted long ago. -->
-  <AncientWarwalkerClaw.description>TODO</AncientWarwalkerClaw.description>
+  <AncientWarwalkerClaw.description>L'artiglio d'assalto di un antico camminatore da guerra di media grandezza. Quest'arma era specializzata nello sfondare pesanti armature di plastacciaio a distanza ravvicinata. I suoi preziosi componenti sono stati saccheggiati molto tempo fa.</AncientWarwalkerClaw.description>
   
   <!-- EN: ancient warwalker foot -->
-  <AncientWarwalkerFoot.label>TODO</AncientWarwalkerFoot.label>
+  <AncientWarwalkerFoot.label>antico piede del camminatore da guerra</AncientWarwalkerFoot.label>
   <!-- EN: A massive foot from an ancient warwalker. It seems to have been torn free from its owner by some kind of heavy weapon. All the useful components were looted or deteriorated long ago. -->
   <AncientWarwalkerFoot.description>TODO</AncientWarwalkerFoot.description>
   
   <!-- EN: ancient warwalker leg -->
-  <AncientWarwalkerLeg.label>TODO</AncientWarwalkerLeg.label>
+  <AncientWarwalkerLeg.label>antica gamba del camminatore da guerra</AncientWarwalkerLeg.label>
   <!-- EN: The shattered leg of a mid-scale warwalker that fell here long ago. It has been picked clean by looters, and no valuable components remain. -->
   <AncientWarwalkerLeg.description>TODO</AncientWarwalkerLeg.description>
   
   <!-- EN: ancient warwalker shell -->
-  <AncientWarwalkerShell.label>TODO</AncientWarwalkerShell.label>
+  <AncientWarwalkerShell.label>antica corazza del camminatore da guerra</AncientWarwalkerShell.label>
   <!-- EN: Most of the armored shell of a warwalker. It appears to have been torn off by some colossal weapon system. All the valuable parts were looted, and the rest is badly deteriorated. -->
   <AncientWarwalkerShell.description>TODO</AncientWarwalkerShell.description>
   
   <!-- EN: ancient warwalker torso -->
-  <AncientWarwalkerTorso.label>TODO</AncientWarwalkerTorso.label>
+  <AncientWarwalkerTorso.label>antico torso del camminatore da guerra</AncientWarwalkerTorso.label>
   <!-- EN: The torso of a mid-scale warwalker which fell here in ancient days. The valuable parts were looted long ago. -->
   <AncientWarwalkerTorso.description>TODO</AncientWarwalkerTorso.description>
   
   <!-- EN: ancient wheel -->
-  <AncientWheel.label>TODO</AncientWheel.label>
+  <AncientWheel.label>antica ruota</AncientWheel.label>
   <!-- EN: An ancient wheel from some kind of vehicle. The rubber has deteriorated away and the metal is twisted and rusted. -->
   <AncientWheel.description>TODO</AncientWheel.description>
   


### PR DESCRIPTION
Ho preferito al momento, tradurre solamente il nome dell'oggetto, per velocizzare la traduzione,alla fine il dettaglio, non dice nulla di utile se non solo "un antica ruota ecc" dopo aver finito le varie traduzioni più utili per l'utilizzo del dlc, potremmo concludere le righe di testo non tradotte.